### PR TITLE
Fixed issue with filename in many libraries not allowing trailing / i…

### DIFF
--- a/WifiNode/serverprocess.cpp
+++ b/WifiNode/serverprocess.cpp
@@ -83,6 +83,10 @@ void handleFileUpload(AsyncWebServerRequest *request, String filename, size_t in
     return;
   }
 
+  if (!filename.startsWith("/")) {
+      filename = "/" + filename;
+  }
+
   if(g_status==PRINTING){
     request->send(500, "text/plain", "UPLOAD OPEN SF FAILED");
     return;


### PR DESCRIPTION
…n filename multi-part form uploads

This fix will prepend the '/' into the filename if it's missing from the headers.