### PR TITLE
Fixed issue with filename in many libraries not allowing trailing / i…

### DIFF
--- a/WifiNode/serverprocess.cpp
+++ b/WifiNode/serverprocess.cpp
@@ -88,6 +88,10 @@ void handleFileUpload(AsyncWebServerRequest *request, String filename, size_t in
     return;
   }
 
+  if (!filename.startsWith("/")) {
+      filename = "/" + filename;
+  }
+
   //start
   if (!index) {
     espGetSDCard();


### PR DESCRIPTION
NodeJS and Postman both had issues with the filename in the multi-part upload, where it defaulted to the actual filename, but the firmware is expecting a leading '/'. Even when forcing NodeJS to put the '/' in there, it just ignored it, while in Postman this is simply not even possible. So my only option was to fix this in the firmware itself. This might be a useful addition for other as well.